### PR TITLE
fix : lables DTO 엔티티로 바꾸는 메소드 수정

### DIFF
--- a/src/main/java/com/code2am/stocklog/domain/labels/service/LabelsService.java
+++ b/src/main/java/com/code2am/stocklog/domain/labels/service/LabelsService.java
@@ -54,7 +54,7 @@ public class LabelsService {
         Integer userId = authUtil.getUserId();
 
         System.out.println(labelsId);
-        Labels labels = commonUtils.convertLabelsDtoToEntity(updateLabels);
+        Labels labels = updateLabels.convertToEntity();
         labels.setUserId(userId);
 
         labelsRepository.save(labels);


### PR DESCRIPTION
CommonUtils에서 DTO를 Entity로 변환해주는 메소드가 DTO Class로 이동해서 생기던 오류를 수정